### PR TITLE
Rasterizer: Use UBOs instead of SSBOs for uploading const buffers.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -54,6 +54,11 @@ public:
         OGLShader shader;
     };
 
+    /// Maximum supported size that a constbuffer can have in bytes.
+    static constexpr size_t MaxConstbufferSize = 0x1000;
+    static_assert(MaxConstbufferSize % sizeof(GLvec4) == 0,
+                  "The maximum size of a constbuffer must be a multiple of the size of GLvec4");
+
 private:
     class SamplerInfo {
     public:

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -9,6 +9,7 @@
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "video_core/engines/shader_bytecode.h"
+#include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_shader_decompiler.h"
 
 namespace GLShader {
@@ -366,7 +367,8 @@ public:
     /// Generates code representing a uniform (C buffer) register, interpreted as the input type.
     std::string GetUniform(u64 index, u64 offset, GLSLRegister::Type type) {
         declr_const_buffers[index].MarkAsUsed(index, offset, stage);
-        std::string value = 'c' + std::to_string(index) + '[' + std::to_string(offset) + ']';
+        std::string value = 'c' + std::to_string(index) + '[' + std::to_string(offset / 4) + "][" +
+                            std::to_string(offset % 4) + ']';
 
         if (type == GLSLRegister::Type::Float) {
             return value;
@@ -380,8 +382,12 @@ public:
     std::string GetUniformIndirect(u64 index, s64 offset, const Register& index_reg,
                                    GLSLRegister::Type type) {
         declr_const_buffers[index].MarkAsUsedIndirect(index, stage);
-        std::string value = 'c' + std::to_string(index) + "[(floatBitsToInt(" +
-                            GetRegister(index_reg, 0) + ") + " + std::to_string(offset) + ") / 4]";
+
+        std::string final_offset = "((floatBitsToInt(" + GetRegister(index_reg, 0) + ") + " +
+                                   std::to_string(offset) + ") / 4)";
+
+        std::string value =
+            'c' + std::to_string(index) + '[' + final_offset + " / 4][" + final_offset + " % 4]";
 
         if (type == GLSLRegister::Type::Float) {
             return value;
@@ -423,9 +429,10 @@ public:
 
         unsigned const_buffer_layout = 0;
         for (const auto& entry : GetConstBuffersDeclarations()) {
-            declarations.AddLine("layout(std430) buffer " + entry.GetName());
+            declarations.AddLine("layout(std140) uniform " + entry.GetName());
             declarations.AddLine('{');
-            declarations.AddLine("    float c" + std::to_string(entry.GetIndex()) + "[];");
+            declarations.AddLine("    vec4 c" + std::to_string(entry.GetIndex()) +
+                                 "[MAX_CONSTBUFFER_ELEMENTS];");
             declarations.AddLine("};");
             declarations.AddNewLine();
             ++const_buffer_layout;
@@ -1611,7 +1618,10 @@ private:
 }; // namespace Decompiler
 
 std::string GetCommonDeclarations() {
-    return "bool exec_shader();";
+    std::string declarations = "bool exec_shader();\n";
+    declarations += "#define MAX_CONSTBUFFER_ELEMENTS " +
+                    std::to_string(RasterizerOpenGL::MaxConstbufferSize / (sizeof(GLvec4)));
+    return declarations;
 }
 
 boost::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code, u32 main_offset,

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -223,7 +223,7 @@ void OpenGLState::Apply() const {
             if (current.enabled != new_state.enabled || current.bindpoint != new_state.bindpoint ||
                 current.ssbo != new_state.ssbo) {
                 if (new_state.enabled) {
-                    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, new_state.bindpoint, new_state.ssbo);
+                    glBindBufferBase(GL_UNIFORM_BUFFER, new_state.bindpoint, new_state.ssbo);
                 }
             }
         }


### PR DESCRIPTION
This should help a bit with GPU performance once we're GPU-bound.